### PR TITLE
get-pip.py moved from github to pypa.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -s https://mapnik.s3.amazonaws.com/dist/v3.0.9/mapnik-v3.0.9.tar.bz2 | 
 
 # TileStache and dependencies
 RUN ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib
-RUN cd /tmp/ && curl --insecure -Os https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py && python get-pip.py
+RUN cd /tmp/ && curl -Os https://bootstrap.pypa.io/get-pip.py && python get-pip.py
 RUN apt-get install python-pil
 RUN pip install -U modestmaps simplejson werkzeug tilestache --allow-external PIL --allow-unverified PIL
 RUN mkdir -p /etc/tilestache


### PR DESCRIPTION
The original source (https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py) now says:
# !/usr/bin/env python

import sys

def main():
    sys.exit(
        "You're using an outdated location for the get-pip.py script, please "
        "use the one available from https://bootstrap.pypa.io/get-pip.py"
    )

if **name** == "**main**":
    main()
